### PR TITLE
PE-16098 | Upgrade Addressable

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,13 +2,13 @@ PATH
   remote: .
   specs:
     change_healthcare-eligibility (0.3.0)
-      addressable (~> 2.5)
+      addressable (~> 2.8.0)
       typhoeus (~> 1.4)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.7.0)
+    addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     byebug (11.1.3)
     coderay (1.1.3)
@@ -58,4 +58,4 @@ DEPENDENCIES
   simplecov
 
 BUNDLED WITH
-   2.1.4
+   2.2.28

--- a/change_healthcare-eligibility.gemspec
+++ b/change_healthcare-eligibility.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   # needed for autogen swagged client
-  spec.add_dependency 'addressable', '~> 2.5'
+  spec.add_dependency 'addressable', '~> 2.8.0'
   spec.add_dependency 'typhoeus', '~> 1.4'
 
   spec.add_development_dependency 'bundler', '~> 2.0'


### PR DESCRIPTION
There is a known vulnerability in Addressable. This upgrade addresses
that vulnerability.